### PR TITLE
Fix wrong amount shown on UI

### DIFF
--- a/lib/phonepe_ui.dart
+++ b/lib/phonepe_ui.dart
@@ -86,7 +86,7 @@ class _PhonePeUIState extends State<PhonePeUI> {
               ),
               child: Center(
                 child: Text(
-                  "₹ ${(widget.params.amount! / 100)}",
+                  "₹ ${(widget.params.amount!)}",
                   style: const TextStyle(
                     color: Colors.black,
                     fontWeight: FontWeight.bold,


### PR DESCRIPTION
Phonepe expects the amount in paise. 
While consuming the library amount is in rupees, the amount is multiplied by 100 before calling PhonePe API.

This is great! However, the amount shown on the first payment UI is divided by 100. (Lets say user enters 100 rupees it is shown as Rs 1 here and while actually making the payment the amount is 10000 paise).

This UI bug is fixed with this PR